### PR TITLE
Add validate file names workflow

### DIFF
--- a/.github/workflows/validate-file-names.yaml
+++ b/.github/workflows/validate-file-names.yaml
@@ -1,0 +1,9 @@
+name: Validate file names
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+
+jobs:
+  validate:
+    uses: giantswarm/github-workflows/.github/workflows/validate-file-names.yaml@main
+


### PR DESCRIPTION
This PR adds the validate file names workflow to ensure consistent file naming conventions across the repository.

The workflow validates file names on pull requests and can also be triggered manually via workflow_dispatch.

Relates to https://github.com/giantswarm/giantswarm/issues/34641